### PR TITLE
YONK-335: fix organization courses api

### DIFF
--- a/organizations/views.py
+++ b/organizations/views.py
@@ -242,8 +242,9 @@ class OrganizationsViewSet(SecurePaginatedModelViewSet):
         Returns list of courses in an organization
         """
         organization = self.get_object()
-        course_ids = Group.objects.filter(organizations=organization)\
-            .values_list('coursegrouprelationship__course_id', flat=True).distinct()
+        course_ids = User.objects.filter(organizations=organization)\
+            .values_list('courseenrollment__course_id', flat=True).distinct()
+
         course_keys = map(get_course_key, filter(None, course_ids))
         enrollment_qs = CourseEnrollment.objects.filter(is_active=True, course_id__in=course_keys)\
             .values_list('course_id', 'user_id')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='organizations-edx-platform-extensions',
-    version='1.0.1',
+    version='1.0.3',
     description='Organization management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR fixes organization courses api to return courses in which organizations users are enrolled in.

@ziafazal would please review?
