### PR TITLE
YONK-336: fix organization courses list api enrolled_users attribute

### DIFF
--- a/organizations/views.py
+++ b/organizations/views.py
@@ -246,7 +246,8 @@ class OrganizationsViewSet(SecurePaginatedModelViewSet):
             .values_list('courseenrollment__course_id', flat=True).distinct()
 
         course_keys = map(get_course_key, filter(None, course_ids))
-        enrollment_qs = CourseEnrollment.objects.filter(is_active=True, course_id__in=course_keys)\
+        enrollment_qs = CourseEnrollment.objects\
+            .filter(user__organizations=organization, is_active=True, course_id__in=course_keys)\
             .values_list('course_id', 'user_id')
 
         enrollments = {}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='organizations-edx-platform-extensions',
-    version='1.0.3',
+    version='1.0.4',
     description='Organization management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR fixes organization courses list api enrolled_users attribute to return only id’s of users from this organization and enrolled in this course.

@ziafazal please review
