### PR TITLE
YONK-340: add display_name filter to organizations list api

### DIFF
--- a/organizations/tests.py
+++ b/organizations/tests.py
@@ -226,6 +226,34 @@ class OrganizationsApiTests(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), len(organizations))
 
+    def test_organizations_list_get_filter_by_display_name(self):
+        organizations = []
+        organizations.append(self.setup_test_organization(org_data={'display_name': 'Abc Organization'}))
+        organizations.append(self.setup_test_organization(org_data={'display_name': 'Xyz Organization'}))
+        organizations.append(self.setup_test_organization(org_data={'display_name': 'Abc Organization'}))
+
+        # test for not matching organization
+        test_uri = '{}?display_name={}'.format(self.base_organizations_uri, 'no org')
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 0)
+
+        # test for matching organization
+        test_uri = '{}?display_name={}'.format(self.base_organizations_uri, 'Xyz Organization')
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['display_name'], 'Xyz Organization')
+
+        # test for multiple matching organization with same display_name
+        test_uri = '{}?display_name={}'.format(self.base_organizations_uri, 'Abc Organization')
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(response.data['results'][0]['display_name'], 'Abc Organization')
+        self.assertEqual(response.data['results'][1]['display_name'], 'Abc Organization')
+        self.assertNotEqual(response.data['results'][0]['id'], response.data['results'][1]['id'])
+
     def test_organizations_detail_get(self):
         org = self.setup_test_organization()
         test_uri = '{}{}/'.format(self.base_organizations_uri, org['id'])

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -37,6 +37,11 @@ class OrganizationsViewSet(SecurePaginatedModelViewSet):
     def list(self, request, *args, **kwargs):
         self.serializer_class = OrganizationWithCourseCountSerializer
         queryset = self.get_queryset()
+
+        display_name = request.QUERY_PARAMS.get('display_name', None)
+        if display_name is not None:
+            queryset = queryset.filter(display_name=display_name)
+
         self.queryset = queryset.annotate(
             number_of_courses=Count('users__courseenrollment__course_id', distinct=True)
         )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='organizations-edx-platform-extensions',
-    version='1.0.4',
+    version='1.0.5',
     description='Organization management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR adds `display_name` filter to organizations list API, example request: `/api/server/organizations?display_name=abc`

@ziafazal would you please take a look?
