### PR TITLE
ziafazal/YONK-339: added number_of_participants field to organizations list

### DIFF
--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -31,9 +31,10 @@ class BasicOrganizationSerializer(serializers.ModelSerializer):
 class OrganizationWithCourseCountSerializer(BasicOrganizationSerializer):
     """ Serializer for Organization fields with number of courses """
     number_of_courses = serializers.IntegerField(source='number_of_courses')
+    number_of_participants = serializers.IntegerField(source='number_of_participants')
 
     class Meta(object):
         """ Serializer/field specification """
         model = Organization
         fields = ('url', 'id', 'name', 'display_name', 'number_of_courses', 'contact_name', 'contact_email',
-                  'contact_phone', 'logo_url', 'created', 'modified')
+                  'contact_phone', 'logo_url', 'created', 'modified', 'number_of_participants')

--- a/organizations/tests.py
+++ b/organizations/tests.py
@@ -226,6 +226,24 @@ class OrganizationsApiTests(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), len(organizations))
 
+    def test_organizations_list_number_of_participants(self):
+        """
+        Test number_of_participants field in organization list
+        """
+        number_of_participants = 5
+        users = UserFactory.create_batch(number_of_participants)
+        org = self.setup_test_organization()
+
+        # get org list without any users/participants
+        response = self.do_get(self.base_organizations_uri)
+        self.assertEqual(response.data['results'][0]['number_of_participants'], 0)
+
+        for user in users:
+            user.organizations.add(org['id'])
+
+        response = self.do_get(self.base_organizations_uri)
+        self.assertEqual(response.data['results'][0]['number_of_participants'], number_of_participants)
+
     def test_organizations_list_get_filter_by_display_name(self):
         organizations = []
         organizations.append(self.setup_test_organization(org_data={'display_name': 'Abc Organization'}))

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -44,6 +44,8 @@ class OrganizationsViewSet(SecurePaginatedModelViewSet):
 
         self.queryset = queryset.annotate(
             number_of_courses=Count('users__courseenrollment__course_id', distinct=True)
+        ).annotate(
+            number_of_participants=Count('users')
         )
 
         return super(OrganizationsViewSet, self).list(request, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='organizations-edx-platform-extensions',
-    version='1.0.5',
+    version='1.0.6',
     description='Organization management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR has changes to add `number_of_participants` field to organizations list API. number_of_participants are total users registered in an organization.

@msaqib52 would you please review?
