### PR TITLE
count number of participants as distinct

### DIFF
--- a/organizations/tests.py
+++ b/organizations/tests.py
@@ -232,6 +232,7 @@ class OrganizationsApiTests(ModuleStoreTestCase):
         """
         number_of_participants = 5
         users = UserFactory.create_batch(number_of_participants)
+        courses = CourseFactory.create_batch(2)
         org = self.setup_test_organization()
 
         # get org list without any users/participants
@@ -240,6 +241,14 @@ class OrganizationsApiTests(ModuleStoreTestCase):
 
         for user in users:
             user.organizations.add(org['id'])
+
+        response = self.do_get(self.base_organizations_uri)
+        self.assertEqual(response.data['results'][0]['number_of_participants'], number_of_participants)
+
+        # enroll users in both course to test distinct count
+        for user in users:
+            CourseEnrollmentFactory.create(user=user, course_id=courses[0].id)
+            CourseEnrollmentFactory.create(user=user, course_id=courses[1].id)
 
         response = self.do_get(self.base_organizations_uri)
         self.assertEqual(response.data['results'][0]['number_of_participants'], number_of_participants)

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -45,7 +45,7 @@ class OrganizationsViewSet(SecurePaginatedModelViewSet):
         self.queryset = queryset.annotate(
             number_of_courses=Count('users__courseenrollment__course_id', distinct=True)
         ).annotate(
-            number_of_participants=Count('users')
+            number_of_participants=Count('users', distinct=True)
         )
 
         return super(OrganizationsViewSet, self).list(request, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='organizations-edx-platform-extensions',
-    version='1.0.6',
+    version='1.0.8',
     description='Organization management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR has changes to count number of participants distinctly no matter how many courses a user is enrolled in it should count once in number of participants.

@msaqib52 would you please review?
