### PR TITLE
Delete organization field API issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='organizations-edx-platform-extensions',
-    version='1.2.3',
+    version='1.2.6',
     description='Organization management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Changed the database field to unlimited sized field which is TextField in the case of django=1.8. fixed the delete api checks and randomized the key for attributes.

[YONK-1151]