### PR TITLE
[MCKIN-8823] Add management command to fix empty organisation attributes.

### DIFF
--- a/edx_solutions_organizations/management/commands/fix_empty_organization_attributes.py
+++ b/edx_solutions_organizations/management/commands/fix_empty_organization_attributes.py
@@ -1,0 +1,19 @@
+"""
+Management command to fix organisations that have an empty attributes field.
+"""
+import logging
+from django.core.management.base import BaseCommand
+from edx_solutions_organizations.models import Organization
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Command to fix organisations that have an empty attributes entry.
+    """
+    help = 'Updates organizations with an invalid blank attributes entry.'
+
+    def handle(self, *args, **options):
+        fix_count = Organization.objects.filter(attributes='').update(attributes='{}')
+        log.info('Fixed %s Organizations with blank attributes', fix_count)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='organizations-edx-platform-extensions',
-    version='1.2.6',
+    version='1.2.7',
     description='Organization management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Adds a management command that updated organisations that have an empty attributes field and sets it to an empty JSON object. 